### PR TITLE
Update badge to actions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,6 +1,6 @@
 # TMwR
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/a0db3b22-8c6f-40e8-bcef-9de2f99fd428/deploy-status)](https://app.netlify.com/sites/tidy-models-with-r/deploys)
+[![Build Status](https://github.com/tidymodels/TMwR/workflows/bookdown/badge.svg)](https://github.com/tidymodels/TMwR/actions)
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # TMwR
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/a0db3b22-8c6f-40e8-bcef-9de2f99fd428/deploy-status)](https://app.netlify.com/sites/tidy-models-with-r/deploys)
+[![Build Status](https://github.com/tidymodels/TMwR/workflows/bookdown/badge.svg)](https://github.com/tidymodels/TMwR/actions)
+
+
+
 
 This repository contains the source for [_Tidy Modeling with R_](https://tmwr.org). The purpose of this book is to demonstrate how the [tidyverse](https://www.tidyverse.org/) and [tidymodels](https://www.tidymodels.org/) can be used to produce high quality models.
 


### PR DESCRIPTION
There are no more deploys to show from Netlify, so let's switch out the Netlify badge for a bookdown actions badge.

Also let's see if my change to the action is successful in not deploying from a PR.