### PR TITLE
"features" typed twice in a row & without "a"

### DIFF
--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -343,7 +343,7 @@ While not all models can exploit this feature, many broadly used ones do:
 
 * Regularization methods, such as the `r pkg(glmnet)` model, can make simultaneous predictions across the amount of regularization used to fit the model. 
 
-* Multivariate adaptive regression splines (MARS) adds a set of nonlinear features features to a linear regression models [@Friedman:1991p109]. The number of terms to retain is a tuning parameter and it is computationally fast to make predictions across many values of this parameter from a single model fit. 
+* Multivariate adaptive regression splines (MARS) adds a set of nonlinear features to linear regression models [@Friedman:1991p109]. The number of terms to retain is a tuning parameter and it is computationally fast to make predictions across many values of this parameter from a single model fit. 
 
 The `r pkg(tune)` package automatically applies this type of optimization whenever an applicable model is tuned. 
 


### PR DESCRIPTION
1 ) The word "features" is typed twice in a row. 
2) The definite article "a" is not needed since "models" is plural.