### PR TITLE
Remove the juice() function

### DIFF
--- a/08-the-model-workflow.Rmd
+++ b/08-the-model-workflow.Rmd
@@ -133,10 +133,10 @@ lm_wflow <-
 lm_wflow
 ```
 
-We described the `prep()`, `bake()`, and `juice()` functions in Section \@ref(recipes-manual) for using the recipe with a modeling function. This can be onerous, so the `fit()` method for workflow objects automates this process: 
+We described the `prep()` and `bake()` functions in Section \@ref(recipes-manual) for using the recipe with a modeling function. This can be onerous, so the `fit()` method for workflow objects automates this process: 
 
 ```{r workflows-recipe-fit}
-# Does `prep()`, `juice()`, and `fit()` in one step:
+# Does `prep()`, `bake()`, and `fit()` in one step:
 lm_fit <- fit(lm_wflow, ames_train)
 
 # Does `bake()` and `predict()` automatically:


### PR DESCRIPTION
The juice() function is not described in Section \@ref(recipes-manual) - 6.8
Also as of recipes version 0.1.14, juice() is superseded in favor of bake(object, new_data = NULL) so probably better to keep documentation without juice().