### PR TITLE
builds are failing from not having libgit2 installs

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -28,6 +28,7 @@ jobs:
           brew install --cask xquartz
           brew install pkg-config cairo
           brew install v8
+          brew install libgit2
 
       - name: Install pak and query dependencies
         run: |


### PR DESCRIPTION
I'm not sure why this didn't happen in the PR for #121 but builds are failing with

```
Failed to build source package 'gert', stdout + stderr:

OE> * installing *source* package ‘gert’ ...
OE> ** package ‘gert’ successfully unpacked and MD5 sums checked
OE> staged installation is only possible with locking
OE> ** using non-staged installation
OE> Homebrew 3.0.5
OE> Homebrew/homebrew-core (git revision ee84729719; last commit 2021-03-14)
OE> Homebrew/homebrew-cask (git revision aa703eaf8d; last commit 2021-03-14)
OE> Using PKG_CFLAGS=-I/usr/local/opt/libgit2/include
OE> Using PKG_LIBS=-L/usr/local/opt/libgit2/lib -lgit2
OE> ----------------------------- ANTICONF -------------------------------
OE> Configuration failed to find libgit2 library. Try installing:
OE>  * brew: libgit2 (MacOS)
OE>  * deb: libgit2-dev (Debian, Ubuntu, etc)
OE>  * rpm: libgit2-devel (Fedora, CentOS, RHEL)
OE> If libgit2 is already installed, check that 'pkg-config' is in your
OE> PATH and PKG_CONFIG_PATH contains a libgit2.pc file. If pkg-config
OE> is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:
OE> R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
OE> -------------------------- [ERROR MESSAGE] ---------------------------
OE> <stdin>:1:10: fatal error: 'git2.h' file not found
OE> #include <git2.h>
OE>          ^~~~~~~~
OE> 1 error generated.
OE> ----------------------------------------------------------------------
OE> ERROR: configuration failed for package ‘gert’
OE> * removing ‘/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/RtmpmsskLm/pkg-libcc8267bff2a/gert’
 ```

A refresh of the GHA might help although it doesn't appear to install this and I'm apprehensive of making that level fo change. 