### PR TITLE
tidymodels_prefer() updates

### DIFF
--- a/03-base-r.Rmd
+++ b/03-base-r.Rmd
@@ -318,6 +318,40 @@ model_by_species %>%
 List columns can be very powerful in modeling projects. List columns provide containers for any type of R objects, from a fitted model itself to the important data frame structure. 
 :::
 
+## The tidymodels package
+
+The design philosophy of the tidyverse is to create modular R packages, each with a fairly narrow scope. The tidymodels package follow a similar design. For example, `r pkg(rsample)` package focus on data splitting and resampling. Although resampling methods are critical to other activities of modeling (e.g., measuring performance), they reside in a one package and performance metrics are contained in the `r pkg(yardstick)` package.  The downside to this philosophy is that there are a lot of packages in the tidymodels organization.  
+
+```{r base-r-detach, warning = FALSE, message = FALSE, echo = FALSE}
+pkgs <- paste0("package:", c("tidymodels", tidymodels:::core))
+for (i in pkgs) {
+  try(detach(i, unload = TRUE, character.only = TRUE, force = TRUE), silent = TRUE)
+}
+```
+
+To compensate for this, the tidymodels _package_ loads a core set of tidymodels and tidyverse packages. Loading the package shows which package are attached and if there are function naming conflicts with previously loaded packages:
+
+```{r base-r-tidymodels-package}
+library(tidymodels)
+```
+
+As an example of a naming conflict, before loading `r pkg(tidymodels)`, invoking the `filter()` function will execute the function in the `r pkg(stats)` package. After loading tidymodels, it will execute the `r pkg(dplyr)` function. 
+
+There are a few ways to handle naming conflicts. As previously mentioned, the function can be called with its namespace (e.g., `stats::filter()`). This is not bad advice but it does make the code less readable. 
+
+Another option is to use the `r pkg(conflicted)` package. A rule can be set that remains in effect until the end of the R session that ensures that one specific function will always run if no namespace is given in the code. As an example, if we prefer the `r pkg(dplyr)` version of the function:
+
+```{r base-r-conflicted, eval = FALSE}
+library(conflicted)
+conflict_prefer("filter", winner = "dplyr")
+```
+
+As another convenience, `r pkg(tidymodels)` contains a function that captures most of the common naming conflicts that we might encounter:
+
+```{r base-r-clonflicts}
+tidymodels_prefer(quiet = FALSE)
+```
+
 ## Chapter summary
 
 This chapter reviewed core R language conventions for creating and using models that are an important foundation for the rest of this book. The formula operator is an expressive and important aspect of fitting models in R and often serves multiple purposes in non-tidymodels functions. Traditional R approaches to modeling have some limitations, especially when it comes to fluently handling and visualizing model output. 

--- a/03-base-r.Rmd
+++ b/03-base-r.Rmd
@@ -318,9 +318,9 @@ model_by_species %>%
 List columns can be very powerful in modeling projects. List columns provide containers for any type of R objects, from a fitted model itself to the important data frame structure. 
 :::
 
-## The tidymodels package
+## The tidymodels metapackage
 
-The design philosophy of the tidyverse is to create modular R packages, each with a fairly narrow scope. The tidymodels package follow a similar design. For example, `r pkg(rsample)` package focus on data splitting and resampling. Although resampling methods are critical to other activities of modeling (e.g., measuring performance), they reside in a one package and performance metrics are contained in the `r pkg(yardstick)` package.  The downside to this philosophy is that there are a lot of packages in the tidymodels organization.  
+The tidyverse (Chapter \@ref(tidyverse)) is designed as a set of modular R packages, each with a fairly narrow scope. The tidymodels framework follows a similar design. For example, the `r pkg(rsample)` package focuses on data splitting and resampling. Although resampling methods are critical to other activities of modeling (e.g., measuring performance), they reside in a single package and performance metrics are contained in a different, separate package, `r pkg(yardstick)`. There are many benefits to adopting this philosophy of modular packages, from less bloated model deployment to smoother package maintenance.
 
 ```{r base-r-detach, warning = FALSE, message = FALSE, echo = FALSE}
 pkgs <- paste0("package:", c("tidymodels", tidymodels:::core))
@@ -329,29 +329,33 @@ for (i in pkgs) {
 }
 ```
 
-To compensate for this, the tidymodels _package_ loads a core set of tidymodels and tidyverse packages. Loading the package shows which package are attached and if there are function naming conflicts with previously loaded packages:
+The downside to this philosophy is that there are a lot of packages in the tidymodels organization. To compensate for this, the tidymodels _package_ (which you can think of as a "metapackage" like the tidyverse package) loads a core set of tidymodels and tidyverse packages. Loading the package shows which packages are attached and if there are function naming conflicts with previously loaded packages:
 
 ```{r base-r-tidymodels-package}
 library(tidymodels)
 ```
 
-As an example of a naming conflict, before loading `r pkg(tidymodels)`, invoking the `filter()` function will execute the function in the `r pkg(stats)` package. After loading tidymodels, it will execute the `r pkg(dplyr)` function. 
+As an example of a naming conflict, before loading `r pkg(tidymodels)`, invoking the `filter()` function will execute the function in the `r pkg(stats)` package. After loading tidymodels, it will execute the `r pkg(dplyr)` function of the same name. 
 
-There are a few ways to handle naming conflicts. As previously mentioned, the function can be called with its namespace (e.g., `stats::filter()`). This is not bad advice but it does make the code less readable. 
+There are a few ways to handle naming conflicts. The function can be called with its namespace (e.g., `stats::filter()`). This is not bad practice but it does make the code less readable. 
 
-Another option is to use the `r pkg(conflicted)` package. A rule can be set that remains in effect until the end of the R session that ensures that one specific function will always run if no namespace is given in the code. As an example, if we prefer the `r pkg(dplyr)` version of the function:
+Another option is to use the `r pkg(conflicted)` package. We can set a rule that remains in effect until the end of the R session to ensure that one specific function will always run if no namespace is given in the code. As an example, if we prefer the `r pkg(dplyr)` version of the above function:
 
 ```{r base-r-conflicted, eval = FALSE}
 library(conflicted)
 conflict_prefer("filter", winner = "dplyr")
 ```
 
-As another convenience, `r pkg(tidymodels)` contains a function that captures most of the common naming conflicts that we might encounter:
+For convenience, `r pkg(tidymodels)` contains a function that captures most of the common naming conflicts that we might encounter:
 
 ```{r base-r-clonflicts}
 tidymodels_prefer(quiet = FALSE)
 ```
 
+:::rmdwarning
+Be aware that using this function opts you in to using `conflicted::conflict_prefer()` for _all_ namespace conflicts, making every conflict an error and forcing you to choose which function to use. The function `tidymodels::tidymodels_prefer()` handles the most common conflicts from tidymodels functions, but you will need to handle other conflicts in your R session yourself. 
+:::
+
 ## Chapter summary
 
-This chapter reviewed core R language conventions for creating and using models that are an important foundation for the rest of this book. The formula operator is an expressive and important aspect of fitting models in R and often serves multiple purposes in non-tidymodels functions. Traditional R approaches to modeling have some limitations, especially when it comes to fluently handling and visualizing model output. 
+This chapter reviewed core R language conventions for creating and using models that are an important foundation for the rest of this book. The formula operator is an expressive and important aspect of fitting models in R and often serves multiple purposes in non-tidymodels functions. Traditional R approaches to modeling have some limitations, especially when it comes to fluently handling and visualizing model output. The `r pkg(tidymodels)` metapackage applies tidyverse design philosophy to modeling packages.

--- a/04-ames.Rmd
+++ b/04-ames.Rmd
@@ -2,6 +2,7 @@
 knitr::opts_chunk$set(fig.path = "figures/")
 library(tidymodels)
 data(ames)
+tidymodels_prefer()
 ```
 
 # (PART\*) Basics {-} 
@@ -45,6 +46,9 @@ dim(ames)
 It makes sense to start with the outcome we want to predict: the last sale price of the house (in USD): 
 
 ```{r ames-sale_price, out.width = '100%', fig.width=8, fig.height=3}
+library(tidymodels)
+tidymodels_prefer()
+
 ggplot(ames, aes(x = Sale_Price)) + 
   geom_histogram(bins = 50)
 ```

--- a/05-data-spending.Rmd
+++ b/05-data-spending.Rmd
@@ -1,6 +1,7 @@
 ```{r spending-setup, include = FALSE}
 knitr::opts_chunk$set(fig.path = "figures/")
 library(tidymodels)
+tidymodels_prefer()
 
 source("ames_snippets.R")
 ```
@@ -30,6 +31,9 @@ How should we conduct this split of the data? This depends on the context.
 Suppose we allocate 80% of the data to the training set and the remaining 20% for testing.  The most common method is to use simple random sampling. The [`r pkg(rsample)`](https://rsample.tidymodels.org/) package has tools for making data splits such as this; the function `intial_split()` was created for this purpose. It takes the data frame as an argument as well as the proportion to be placed into training. Using the previous data frame produced by the code snippet from the summary in Section \@ref(ames-summary): 
 
 ```{r ames-split, message = FALSE, warning = FALSE}
+library(tidymodels)
+tidymodels_prefer()
+
 # Set the random number stream using `set.seed()` so that the results can be 
 # reproduced later. 
 set.seed(123)

--- a/06-feature-engineering.Rmd
+++ b/06-feature-engineering.Rmd
@@ -3,6 +3,8 @@ knitr::opts_chunk$set(fig.path = "figures/")
 library(tidymodels)
 library(kableExtra)
 
+tidymodels_prefer()
+
 val_list <- function(x) {
   x <- format(table(x), big.mark = ",")
   x <- paste0("`", names(x), "` ($n = ", unname(x), "$)")
@@ -68,6 +70,7 @@ A recipe is also an object that defines a series of steps for data processing. U
 
 ```{r engineering-ames-simple-recipe}
 library(tidymodels) # Includes the recipes package
+tidymodels_prefer()
 
 simple_ames <- 
   recipe(Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type,

--- a/07-fitting-models.Rmd
+++ b/07-fitting-models.Rmd
@@ -5,6 +5,8 @@ library(kknn)
 library(kableExtra)
 library(tidyr)
 
+tidymodels_prefer()
+
 source("ames_snippets.R")
 ```
 
@@ -65,6 +67,9 @@ For tidymodels, the approach to specifying a model is intended to be more unifie
 These specifications are built _without referencing the data_. For example, for the three cases above: 
 
 ```{r models-lin-reg-spec}
+library(tidymodels)
+tidymodels_prefer()
+
 linear_reg() %>% set_engine("lm")
 
 linear_reg() %>% set_engine("glmnet") 

--- a/08-the-model-workflow.Rmd
+++ b/08-the-model-workflow.Rmd
@@ -3,7 +3,7 @@ knitr::opts_chunk$set(fig.path = "figures/")
 library(tidymodels)
 library(workflowsets)
 library(kableExtra)
-
+tidymodels_prefer()
 source("ames_snippets.R")
 ```
 
@@ -64,6 +64,7 @@ The `r pkg(workflows)` package allows the user to bind modeling and preprocessin
 
 ```{r workflows-simple}
 library(tidymodels)  # Includes the workflows package
+tidymodels_prefer()
 
 lm_model <- 
   linear_reg() %>% 

--- a/09-judging-model-effectiveness.Rmd
+++ b/09-judging-model-effectiveness.Rmd
@@ -2,7 +2,7 @@
 knitr::opts_chunk$set(fig.path = "figures/")
 library(tidymodels)
 library(kableExtra)
-
+tidymodels_prefer()
 source("ames_snippets.R")
 load("RData/lm_fit.RData")
 

--- a/10-resampling.Rmd
+++ b/10-resampling.Rmd
@@ -4,7 +4,7 @@ library(tidymodels)
 library(doMC)
 library(kableExtra)
 library(tidyr)
-
+tidymodels_prefer()
 registerDoMC(cores = parallel::detectCores())
 
 source("ames_snippets.R")

--- a/11-comparing-models.Rmd
+++ b/11-comparing-models.Rmd
@@ -10,6 +10,8 @@ library(tidyr)
 library(forcats)
 registerDoMC(cores = parallel::detectCores())
 
+tidymodels_prefer()
+
 source("ames_snippets.R")
 load("RData/resampling.RData")
 load("RData/post_intervals.RData")
@@ -28,7 +30,8 @@ In either case, the result is a collection of resampled summary statistics (e.g.
 Previously, Section \@ref(workflow-sets-intro) describes the idea of a workflow set where different preprocessors and/or models can be combinatorially generated. In the last chapter, we used a recipe for the Ames data that included an interaction term as well as spline functions for longitude and latitude. To demonstrate more with workflow sets, let's create different linear models that add these preprocessing steps incrementally. We'll create three recipes then combine them into a workflow set: 
 
 ```{r compare-workflow-set}
-library(workflowsets)
+library(tidymodels)
+tidymodels_prefer()
 
 basic_rec <- 
   recipe(Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type + 

--- a/12-tuning-parameters.Rmd
+++ b/12-tuning-parameters.Rmd
@@ -6,6 +6,8 @@ library(ggforce)
 library(doMC)
 registerDoMC(cores = parallel::detectCores())
 
+tidymodels_prefer()
+
 ## -----------------------------------------------------------------------------
 
 source("ames_snippets.R")
@@ -125,6 +127,9 @@ Each of these models result in linear class boundaries. Which one should be we u
 For a data frame `training_set`, let's create a function to compute the different models and extract the likelihood statistics for the training set (using `broom::glance()`): 
 
 ```{r tuning-likelihood}
+library(tidymodels)
+tidymodels_prefer()
+
 llhood <- function(...) {
   logistic_reg() %>% 
     set_engine("glm", ...) %>% 

--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -13,6 +13,8 @@ registerDoMC(cores = parallel::detectCores(logical = TRUE))
 
 library(kableExtra)
 
+tidymodels_prefer()
+
 ## -----------------------------------------------------------------------------
 
 load("RData/mlp_times.RData")
@@ -44,6 +46,9 @@ Historically, the number of epochs was determined by early stopping; a separate 
 Using `r pkg(parsnip)`, the specification for a classification model fit using the `r pkg(nnet)` package is: 
 
 ```{r grid-mlp}
+library(tidymodels)
+tidymodels_prefer()
+
 mlp_spec <- 
   mlp(hidden_units = tune(), penalty = tune(), epochs = tune()) %>% 
   set_engine("nnet", trace = 0) %>% 

--- a/14-iterative-search.Rmd
+++ b/14-iterative-search.Rmd
@@ -7,6 +7,7 @@ library(kableExtra)
 library(av)
 library(doMC)
 registerDoMC(cores = parallel::detectCores(logical = TRUE))
+tidymodels_prefer()
 
 ## -----------------------------------------------------------------------------
 
@@ -45,6 +46,9 @@ The SVM model uses a dot-product and, for this reason, it is necessary to center
 Along with the previously used objects (shown in Section \@ref(grid-summary)), the following tidymodels objects define the model process: 
 
 ```{r iterative-svm-defs, message = FALSE}
+library(tidymodels)
+tidymodels_prefer()
+
 svm_rec <- 
   recipe(class ~ ., data = cells) %>%
   step_YeoJohnson(all_predictors()) %>%

--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -6,7 +6,7 @@ library(workflowsets)
 library(baguette)
 library(rules)
 library(finetune)
-
+tidymodels_prefer()
 caching <- FALSE
 
 cores <- parallel::detectCores()
@@ -40,6 +40,7 @@ First, let's define the data splitting and resampling schemes.
 
 ```{r workflow-sets-data}
 library(tidymodels)
+tidymodels_prefer()
 data(concrete, package = "modeldata")
 glimpse(concrete)
 ```
@@ -171,8 +172,6 @@ Workflow sets take named lists of preprocessors and model specifications and com
 As a first workflow set example, let's combine the recipe that only standardizes the predictors to the nonlinear models that require that the predictors be in the same units. 
 
 ```{r workflow-sets-normalized}
-library(workflowsets)
-
 normalized <- 
    workflow_set(
       preproc = list(normalized = normalized_rec), 

--- a/16-encoding-categorical-data.Rmd
+++ b/16-encoding-categorical-data.Rmd
@@ -1,5 +1,6 @@
 ```{r categorical-setup, include = FALSE}
 library(tidymodels)
+tidymodels_prefer()
 ```
 
 # (PART\*) Other Topics {-} 

--- a/17-dimensionality-reduction.Rmd
+++ b/17-dimensionality-reduction.Rmd
@@ -1,5 +1,6 @@
 ```{r dimensionality-setup, include = FALSE}
 library(tidymodels)
+tidymodels_prefer()
 ```
 
 # Dimensionality reduction  {#dimensionality}

--- a/18-explaining-models-and-predictions.Rmd
+++ b/18-explaining-models-and-predictions.Rmd
@@ -1,5 +1,6 @@
 ```{r explain-setup, include = FALSE}
 library(tidymodels)
+tidymodels_prefer()
 ```
 
 # Explaining models and predictions {#explain}

--- a/19-when-should-you-trust-predictions.Rmd
+++ b/19-when-should-you-trust-predictions.Rmd
@@ -2,6 +2,7 @@
 library(tidymodels)
 library(probably)
 library(applicable)
+tidymodels_prefer()
 ```
 
 # When should you trust predictions? {#trust}

--- a/20-ensemble-models.Rmd
+++ b/20-ensemble-models.Rmd
@@ -1,6 +1,7 @@
 ```{r ensemble-setup, include = FALSE}
 library(tidymodels)
 library(stacks)
+tidymodels_prefer()
 ```
 
 # Ensemble Models {#ensemble}

--- a/21-inferential-analysis.Rmd
+++ b/21-inferential-analysis.Rmd
@@ -1,5 +1,6 @@
 ```{r inferential-setup, include = FALSE}
 library(tidymodels)
+tidymodels_prefer()
 ```
 
 # Inferential analysis {#inferential}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Imports:
   sessioninfo,
   stacks,
   tibble (>= 3.1.0),
-  tidymodels,
+  tidymodels (>= 0.1.3),
   tidyposterior (>= 0.0.3),
   tidyverse,
   themis,
@@ -75,7 +75,5 @@ Imports:
   xgboost,
   yardstick
 Remotes:
-  tidymodels/tidymodels,
-  tidymodels/tidyposterior,
   tidymodels/finetune
 


### PR DESCRIPTION
Added a section on the `tidymodels` package and updated chapters to (mostly) have

```r
library(tidymodels)
tidymodels_prefer()
``` 

when we start to use our code. 

I didn't do it for all chapters since some heavily rely on objects from previous chapters. 