### PR TITLE
Switch from `map2()` to `map()` in Ch 8 example

### DIFF
--- a/08-the-model-workflow.Rmd
+++ b/08-the-model-workflow.Rmd
@@ -304,7 +304,7 @@ In the meantime, let's create model fits for each formula and save them in a new
 ```{r workflows-set-fit}
 location_models <-
    location_models %>%
-   mutate(fit = map2(info, wflow_id, ~ fit(.x$workflow[[1]], ames_train)))
+   mutate(fit = map(info, ~ fit(.x$workflow[[1]], ames_train)))
 location_models
 location_models$fit[[1]]
 ```


### PR DESCRIPTION
Closes #135 

Since that `wflow_id` isn't being used, we only need to use `purrr::map()`.