### PR TITLE
simplify formula

### DIFF
--- a/03-base-r.Rmd
+++ b/03-base-r.Rmd
@@ -74,7 +74,7 @@ rate ~ (temp + species)^2
 
 # Another shortcut to expand factors to include all possible
 # interactions (equivalent for this example):
-rate ~ (temp * species)^2
+rate ~ temp * species
 ```
 
 In addition to the convenience of automatically creating indicator variables, the formula offers a few other niceties: 


### PR DESCRIPTION
Is the `()^2` in the example for specifying all possible interactions intensional? I found it a bit confusing since it doesn't limit interactions to two-way interactions if the variables are combined with `*` as in the second example.

``` r
data(mtcars)

# limits to 2-way interactions
lm(mpg ~ (cyl + disp)^2, data = mtcars)
#> 
#> Call:
#> lm(formula = mpg ~ (cyl + disp)^2, data = mtcars)
#> 
#> Coefficients:
#> (Intercept)          cyl         disp     cyl:disp  
#>    49.03721     -3.40524     -0.14553      0.01585
lm(mpg ~ (cyl + disp + hp)^2, data = mtcars)
#> 
#> Call:
#> lm(formula = mpg ~ (cyl + disp + hp)^2, data = mtcars)
#> 
#> Coefficients:
#> (Intercept)          cyl         disp           hp     cyl:disp       cyl:hp  
#>   5.601e+01   -4.427e+00   -1.184e-01   -1.142e-01    1.439e-02    1.556e-02  
#>     disp:hp  
#>  -8.567e-05

# does not
lm(mpg ~ (cyl * disp * hp)^2, data = mtcars)
#> 
#> Call:
#> lm(formula = mpg ~ (cyl * disp * hp)^2, data = mtcars)
#> 
#> Coefficients:
#> (Intercept)          cyl         disp           hp     cyl:disp       cyl:hp  
#>   9.290e+01   -1.059e+01   -3.865e-01   -4.703e-01    5.270e-02    6.734e-02  
#>     disp:hp  cyl:disp:hp  
#>   2.808e-03   -3.841e-04
```

<sup>Created on 2021-05-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>