### PR TITLE
Express limitations in terms of "too little data here" rather than "too much elsewhere"

### DIFF
--- a/05-data-spending.Rmd
+++ b/05-data-spending.Rmd
@@ -97,7 +97,7 @@ Are there situations when random sampling is not the best choice? One case is wh
 
 ## What proportion should be used? 
 
-The amount of data that should be allocated when splitting the data is highly dependent on the context of the problem at hand. Too little data in the training set handicaps the model's ability to find appropriate parameter estimates. Conversely, too little data in the test set lowers the quality of the performance estimates. There are parts of the statistics community that eschew test sets in general because they believe all of the data should be used for parameter estimation. While there is merit to this argument, it is good modeling practice to have an unbiased set of observations as the final arbiter of model quality. A test set should be avoided only when the data are pathologically small.
+The proportion of data that should be allocated for splitting is highly dependent on the context of the problem at hand. Too little data in the training set hampers the model's ability to find appropriate parameter estimates. Conversely, too little data in the test set lowers the quality of the performance estimates. There are parts of the statistics community that eschew test sets in general because they believe all of the data should be used for parameter estimation. While there is merit to this argument, it is good modeling practice to have an unbiased set of observations as the final arbiter of model quality. A test set should be avoided only when the data are pathologically small.
 
 ## What about a validation set? 
 

--- a/05-data-spending.Rmd
+++ b/05-data-spending.Rmd
@@ -97,7 +97,7 @@ Are there situations when random sampling is not the best choice? One case is wh
 
 ## What proportion should be used? 
 
-The amount of data that should be allocated when splitting the data is highly dependent on the context of the problem at hand. Too much data in the training set lowers the quality of the performance estimates. Conversely, too much data in the test set handicaps the model's ability to find appropriate parameter estimates. There are parts of the statistics community that eschew test sets in general because they believe all of the data should be used for parameter estimation. While there is merit to this argument, it is good modeling practice to have an unbiased set of observations as the final arbiter of model quality. A test set should be avoided only when the data are pathologically small.
+The amount of data that should be allocated when splitting the data is highly dependent on the context of the problem at hand. Too little data in the training set handicaps the model's ability to find appropriate parameter estimates. Conversely, too little data in the test set lowers the quality of the performance estimates. There are parts of the statistics community that eschew test sets in general because they believe all of the data should be used for parameter estimation. While there is merit to this argument, it is good modeling practice to have an unbiased set of observations as the final arbiter of model quality. A test set should be avoided only when the data are pathologically small.
 
 ## What about a validation set? 
 


### PR DESCRIPTION
> Too much data in the training set lowers the quality of the performance estimates. Conversely, too much data in the test set handicaps the model’s ability to find appropriate parameter estimates

I thought it might be more straightforward to express that in terms of "too little" data.
