### PR TITLE
add night-theme support

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,3 +15,10 @@
   background-image: url("images/warning.png");
 }
 
+.book.color-theme-2 .rmdnote {
+  color: #b7c3d4;
+}
+
+.book.color-theme-2 .rmdwarning {
+  color: #bcb7cc;
+}


### PR DESCRIPTION
This should provide more eyeball friendly coloring for the divtips when using the night-mode in gitbook. Only `rmdnote` and `rmdwarning` appeared to be implemented, so that's all I added