### PR TITLE
Prevent BLAS Replacement from spinning up too many threads

### DIFF
--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -12,10 +12,14 @@ theme_set(theme_bw())
 library(doMC)
 registerDoMC(cores = parallel::detectCores(logical = TRUE))
 
-#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
-library(RhpcBLASctl)
-omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
+         paste(sessionInfo()$BLAS,sessionInfo()$LAPACK),
+         ignore.case = TRUE)) {
+  #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+  library(RhpcBLASctl)
+  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+}
 
 library(kableExtra)
 

--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -15,6 +15,7 @@ registerDoMC(cores = parallel::detectCores(logical = TRUE))
 #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
 library(RhpcBLASctl)
 omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
 
 library(kableExtra)
 

--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -5,11 +5,16 @@ library(finetune)
 library(ggforce)
 library(av)
 library(lme4)
+
 data(cells)
 theme_set(theme_bw())
 
 library(doMC)
 registerDoMC(cores = parallel::detectCores(logical = TRUE))
+
+#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+library(RhpcBLASctl)
+omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
 
 library(kableExtra)
 

--- a/14-iterative-search.Rmd
+++ b/14-iterative-search.Rmd
@@ -10,10 +10,14 @@ registerDoMC(cores = parallel::detectCores(logical = TRUE))
 tidymodels_prefer()
 
 
-#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
-library(RhpcBLASctl)
-omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
+         paste(sessionInfo()$BLAS,sessionInfo()$LAPACK),
+         ignore.case = TRUE)) {
+  #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+  library(RhpcBLASctl)
+  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+}
 
 ## -----------------------------------------------------------------------------
 

--- a/14-iterative-search.Rmd
+++ b/14-iterative-search.Rmd
@@ -9,6 +9,12 @@ library(doMC)
 registerDoMC(cores = parallel::detectCores(logical = TRUE))
 tidymodels_prefer()
 
+
+#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+library(RhpcBLASctl)
+omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+
 ## -----------------------------------------------------------------------------
 
 source("extras/verify_results.R")

--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -19,10 +19,14 @@ if (!grepl("mingw32", R.Version()$platform)) {
   registerDoParallel(cl)
 }
 
-#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
-library(RhpcBLASctl)
-omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
+         paste(sessionInfo()$BLAS,sessionInfo()$LAPACK),
+         ignore.case = TRUE)) {
+  #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+  library(RhpcBLASctl)
+  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+}
 
 ```
 

--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -18,6 +18,12 @@ if (!grepl("mingw32", R.Version()$platform)) {
   cl <- makePSOCKcluster(cores)
   registerDoParallel(cl)
 }
+
+#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+library(RhpcBLASctl)
+omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+
 ```
 
 # Screening many models  {#workflow-sets}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Imports:
     purrr,
     ranger,
     recipes (>= 0.1.16),
+    RhpcBLASctl,
     rlang,
     rmarkdown,
     rpart,


### PR DESCRIPTION
When I knitted the book on a new processor (2x AMD 7413 w/ OpenBLAS 0.3.15) without big speculative execution penalties for context switching, it ran OK, but when I ran it on older processors ( Xeon E5-2699 v4 w/ MKL, Xeon E5-2450 w/ MKL), the fact that there were 10x the number of threads as there were processors really slowed things down.

I'm not yet sure if its better to just go down to 1 thread per process or keep it as it is and allow it to scale up to the number of available cores assuming 10 processes, which seems to be the default.

tune_grid() is the biggest offending function, but there seem to be others in the tuning chapters

Note, I still can't haven't gotten it running quickly on the Haswell (E5-2699 v4) chip ... its at 8 hours and counting ... so I simply won't be using that machine to follow along as I read the book.