### PR TITLE
Single-threaded Execution under BLAS replacements for Compatability

### DIFF
--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -12,10 +12,14 @@ theme_set(theme_bw())
 library(doMC)
 registerDoMC(cores = parallel::detectCores(logical = TRUE))
 
-#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
-library(RhpcBLASctl)
-omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
+         paste(sessionInfo()$BLAS,sessionInfo()$LAPACK),
+         ignore.case = TRUE)) {
+  #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+  library(RhpcBLASctl)
+  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+}
 
 library(kableExtra)
 

--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -17,8 +17,8 @@ if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
          ignore.case = TRUE)) {
   #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
   library(RhpcBLASctl)
-  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  omp_set_num_threads(1)
+  blas_set_num_threads(1)
 }
 
 library(kableExtra)

--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -15,6 +15,7 @@ registerDoMC(cores = parallel::detectCores(logical = TRUE))
 #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
 library(RhpcBLASctl)
 omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
 
 library(kableExtra)
 

--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -5,11 +5,16 @@ library(finetune)
 library(ggforce)
 library(av)
 library(lme4)
+
 data(cells)
 theme_set(theme_bw())
 
 library(doMC)
 registerDoMC(cores = parallel::detectCores(logical = TRUE))
+
+#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+library(RhpcBLASctl)
+omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
 
 library(kableExtra)
 

--- a/14-iterative-search.Rmd
+++ b/14-iterative-search.Rmd
@@ -10,10 +10,14 @@ registerDoMC(cores = parallel::detectCores(logical = TRUE))
 tidymodels_prefer()
 
 
-#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
-library(RhpcBLASctl)
-omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
+         paste(sessionInfo()$BLAS,sessionInfo()$LAPACK),
+         ignore.case = TRUE)) {
+  #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+  library(RhpcBLASctl)
+  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+}
 
 ## -----------------------------------------------------------------------------
 

--- a/14-iterative-search.Rmd
+++ b/14-iterative-search.Rmd
@@ -9,6 +9,12 @@ library(doMC)
 registerDoMC(cores = parallel::detectCores(logical = TRUE))
 tidymodels_prefer()
 
+
+#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+library(RhpcBLASctl)
+omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+
 ## -----------------------------------------------------------------------------
 
 source("extras/verify_results.R")

--- a/14-iterative-search.Rmd
+++ b/14-iterative-search.Rmd
@@ -15,8 +15,8 @@ if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
          ignore.case = TRUE)) {
   #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
   library(RhpcBLASctl)
-  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  omp_set_num_threads(1)
+  blas_set_num_threads(1)
 }
 
 ## -----------------------------------------------------------------------------

--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -19,10 +19,14 @@ if (!grepl("mingw32", R.Version()$platform)) {
   registerDoParallel(cl)
 }
 
-#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
-library(RhpcBLASctl)
-omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
+         paste(sessionInfo()$BLAS,sessionInfo()$LAPACK),
+         ignore.case = TRUE)) {
+  #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+  library(RhpcBLASctl)
+  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+}
 
 ```
 

--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -18,6 +18,12 @@ if (!grepl("mingw32", R.Version()$platform)) {
   cl <- makePSOCKcluster(cores)
   registerDoParallel(cl)
 }
+
+#tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
+library(RhpcBLASctl)
+omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+
 ```
 
 # Screening many models  {#workflow-sets}

--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -24,8 +24,8 @@ if(grepl("(MKL|OpenBLAS|GotoBLAS|ACML)",
          ignore.case = TRUE)) {
   #tune_grid takes 10 threads ... make sure that any multithreaded BLAS replacements are not stepping on top of each other (context switching is bad)
   library(RhpcBLASctl)
-  omp_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
-  blas_set_num_threads(floor(get_num_cores() / 10) %>% max(1))
+  omp_set_num_threads(1)
+  blas_set_num_threads(1)
 }
 
 ```

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Imports:
     purrr,
     ranger,
     recipes (>= 0.1.16),
+    RhpcBLASctl,
     rlang,
     rmarkdown,
     rpart,


### PR DESCRIPTION
When I knitted the book on a new AMD 7413 w/ OpenBLAS 0.3.15, it went well, but on a couple of older machines (An Intel Haswell E5-2699 v4 and an Intel Sandy Bridge E5-2450, both with MKL 2020.0.166 ... I think those with speculative execution mitigations that make context-switching very slow), the code (mainly tune_grid()) would run for 10 hours or more.

The solution was to turn it down to one BLAS/LAPACK thread per process, and then the book knits just fine.