### PR TITLE
Do not cache pkg list

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -41,7 +41,7 @@ The tidymodels packages are fairly young in the software lifecycle. We will do o
 
 This book was written in [RStudio](http://www.rstudio.com/ide/) using [bookdown](http://bookdown.org/). The [`tmwr.org`](https://tmwr.org) website is hosted via [Netlify](http://netlify.com/), and automatically built after every push by [GitHub Actions](https://help.github.com/actions). The complete source is available on [GitHub](https://github.com/tidymodels/TMwR). We generated all plots in this book using [ggplot2](https://ggplot2.tidyverse.org/) and its black and white theme (`theme_bw()`). This version of the book was built with `r R.version.string`, [pandoc](https://pandoc.org/) version `r rmarkdown::pandoc_version()`, and the following packages:
 
-```{r pkg-list, echo = FALSE, results="asis"}
+```{r pkg-list, echo = FALSE, cache = FALSE, results = "asis"}
 deps <- desc::desc_get_deps()
 pkgs <- sort(deps$package[deps$type == "Imports"])
 pkgs <- sessioninfo::package_info(pkgs, dependencies = FALSE)


### PR DESCRIPTION
In working on [SMLTAR](https://smltar.com/) we realized that this chunk will cache, which can spell DISASTER for debugging problems with package versions when locally rendering or eventually for generating PDFs. Let's fix this now while I'm thinking about it.