### PR TITLE
Try to fix borked figure in Ch 19

### DIFF
--- a/19-when-should-you-trust-predictions.Rmd
+++ b/19-when-should-you-trust-predictions.Rmd
@@ -1,6 +1,5 @@
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(fig.path = "figures/")
 library(tidymodels)
 library(applicable)
 library(patchwork)
@@ -74,7 +73,7 @@ print(two_class_mod, digits = 3)
 
 The fitted class boundary is overlaid onto the test set: 
 
-```{r trust-glm-grid, echo = FALSE, fig.width=5, fig.height=5, out.width="70%", fig.align="center", cache = TRUE}
+```{r trust-glm-grid, echo = FALSE, fig.width=5, fig.height=5, out.width="70%", fig.align="center"}
 data_grid <-
   crossing(
     x = seq(-4.5, 4.5, length = 100),


### PR DESCRIPTION
This figure is not happy right now, and has not been for several builds:

![Screen Shot 2021-09-02 at 4 54 28 PM](https://user-images.githubusercontent.com/12505835/131926386-3daec278-3fd6-4bcf-9d02-da0005daef30.png)


Trying to handle it like the other figures, with special caching and taking out the special directory arg in this chapter.