### PR TITLE
Fewer warnings

### DIFF
--- a/06-fitting-models.Rmd
+++ b/06-fitting-models.Rmd
@@ -253,16 +253,16 @@ rand_forest(trees = 1000, min_n = 5) %>%
 
 ## Use the model results
 
-Once the model is created and fit, we can use the results in a variety of ways; we might want to plot, print, or otherwise examine the model output. Several quantities are stored in a `r pkg(parsnip)` model object, including the fitted model. This can be found in an element called `fit`, which can be returned using the `purrr::pluck()` function:
+Once the model is created and fit, we can use the results in a variety of ways; we might want to plot, print, or otherwise examine the model output. Several quantities are stored in a `r pkg(parsnip)` model object, including the fitted model. This can be found in an element called `fit`, which can be returned using the `extract_fit_engine()` function:
 
 ```{r models-pluck}
-lm_form_fit %>% pluck("fit")
+lm_form_fit %>% extract_fit_engine()
 ```
 
 Normal methods can be applied to this object, such as printing, plotting, and so on: 
 
 ```{r models-pluck-coef}
-lm_form_fit %>% pluck("fit") %>% vcov()
+lm_form_fit %>% extract_fit_engine() %>% vcov()
 ```
 
 :::rmdwarning
@@ -274,7 +274,7 @@ One issue with some existing methods in base R is that the results are stored in
 ```{r models-lm-param}
 model_res <- 
   lm_form_fit %>% 
-  pluck("fit") %>% 
+  extract_fit_engine() %>% 
   summary()
 
 # The model coefficient table is accessible via the `coef` method.

--- a/07-the-model-workflow.Rmd
+++ b/07-the-model-workflow.Rmd
@@ -206,7 +206,7 @@ The solution in `workflows` is an optional supplementary model formula that can 
 library(survival)
 
 parametric_model <- 
-  surv_reg() %>% 
+  survival_reg() %>% 
   set_engine("survival")
 
 parametric_workflow <- 
@@ -251,7 +251,7 @@ library(workflowsets)
 location_models <- workflow_set(preproc = location, models = list(lm = lm_model))
 location_models
 location_models$info[[1]]
-pull_workflow(location_models, id = "coords_lm")
+extract_workflow(location_models, id = "coords_lm")
 ```
 
 Workflow sets are mostly designed to work with resampling, which is discussed in Chapter \@ref(resampling). In the object above, the columns `option` and `result` must be populated with specific types of objects that result from resampling. We will demonstrate this in more detail in Chapters \@ref(compare) and  \@ref(workflow-sets).  

--- a/07-the-model-workflow.Rmd
+++ b/07-the-model-workflow.Rmd
@@ -206,7 +206,7 @@ The solution in `workflows` is an optional supplementary model formula that can 
 library(survival)
 
 parametric_model <- 
-  survival_reg() %>% 
+  surv_reg() %>% 
   set_engine("survival")
 
 parametric_workflow <- 

--- a/08-feature-engineering.Rmd
+++ b/08-feature-engineering.Rmd
@@ -144,17 +144,17 @@ The `predict()` method applies the same preprocessing that was used on the train
 predict(lm_fit, ames_test %>% slice(1:3))
 ```
 
-If we need the bare model object or recipe, there are `pull_*` functions that can retrieve them: 
+If we need the bare model object or recipe, there are `extract_*` functions that can retrieve them: 
 
 ```{r workflows-pull}
 # Get the recipe after it has been estimated:
 lm_fit %>% 
-  pull_workflow_prepped_recipe() 
+  extract_recipe(estimated = TRUE)
 
 # To tidy the model fit: 
 lm_fit %>% 
   # This returns the parsnip object:
-  pull_workflow_fit() %>% 
+  extract_fit_parsnip() %>% 
   # Now tidy the linear model object:
   tidy() %>% 
   slice(1:5)
@@ -508,7 +508,7 @@ The `tidy()` method can be called again along with the `id` identifier we specif
 ```{r engineering-lm-tidy-other}
 estimated_recipe <- 
   lm_fit %>% 
-  pull_workflow_prepped_recipe()
+  extract_recipe(estimated = TRUE)
 
 tidy(estimated_recipe, id = "my_id")
 ```

--- a/09-judging-model-effectiveness.Rmd
+++ b/09-judging-model-effectiveness.Rmd
@@ -53,7 +53,7 @@ full_model_fit <-
   ad_mod %>% 
   fit(Class ~ (Genotype + male + age)^3, , data = ad_data)
 
-full_model_fit %>% pluck("fit") 
+full_model_fit %>% extract_fit_engine() 
 
 two_way_fit <-
   ad_mod %>% 
@@ -61,8 +61,8 @@ two_way_fit <-
 
 three_factor_test <- 
   anova(
-    full_model_fit %>% pluck("fit"), 
-    two_way_fit %>% pluck("fit"),
+    full_model_fit %>% extract_fit_engine(), 
+    two_way_fit %>% extract_fit_engine(),
     test = "LRT"
   )
 
@@ -72,8 +72,8 @@ main_effects_fit <-
 
 two_factor_test <- 
   anova(
-    two_way_fit %>% pluck("fit"), 
-    main_effects_fit %>% pluck("fit"),
+    two_way_fit %>% extract_fit_engine(), 
+    main_effects_fit %>% extract_fit_engine(),
     test = "LRT"
   )
 

--- a/10-resampling.Rmd
+++ b/10-resampling.Rmd
@@ -544,14 +544,14 @@ lm_wflow <-
 lm_fit <- lm_wflow %>% fit(data = ames_train)
 
 # Select the recipe: 
-pull_workflow_prepped_recipe(lm_fit)
+extract_recipe(lm_fit, estimated = TRUE)
 ```
 
 We can save the linear model coefficients for a fitted model object from a workflow: 
 
 ```{r resampling-extract-func}
 get_model <- function(x) {
-  pull_workflow_fit(x) %>% tidy()
+  extract_fit_parsnip(x) %>% tidy()
 }
 
 # Test it using: 

--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -186,7 +186,7 @@ Since there is only a single preprocessor, this function creates a set of workfl
 The `wflow_id` column is automatically created but can be modified using a call to `mutate()`. The `info` column contains a tibble with some identifiers and the workflow object. The workflow can be extracted: 
 
 ```{r workflow-sets-get-workflow}
-normalized %>% pull_workflow(id = "normalized_KNN")
+normalized %>% extract_workflow(id = "normalized_KNN")
 ```
 
 The `option` column is a placeholder for any arguments to use when we evaluate the workflow. For example, to add the neural network parameter object:  
@@ -420,13 +420,13 @@ Similar to what we have shown in previous chapters, choosing the final model and
 ```{r workflow-sets-finalize}
 best_results <- 
    race_results %>% 
-   pull_workflow_set_result("boosting") %>% 
+   extract_workflow_set_result("boosting") %>% 
    select_best(metric = "rmse")
 best_results
 
 boosting_test_results <- 
    race_results %>% 
-   pull_workflow("boosting") %>% 
+   extract_workflow("boosting") %>% 
    finalize_workflow(best_results) %>% 
    last_fit(split = concrete_split)
 ```


### PR DESCRIPTION
Uses 

 * ~`survival_reg()` instead of `surv_reg()`~
 * `extract_*()` instead of `pull_*()`

(edit: `survival_reg()` doesn't have a `fit()` method until ew release censored)

We are still getting unexpected (to me) warnings in section 10.5 though:

```
ctrl <- control_resamples(extract = get_model)

lm_res <- lm_wflow %>%  fit_resamples(resamples = ames_folds, control = ctrl)
lm_res
#> Warning: This tuning result has notes. Example notes on model fitting include:
#> internal: `pull_workflow_fit()` was deprecated in workflows 0.2.3.
#> Please use `extract_fit_parsnip()` instead.
#> internal: `pull_workflow_fit()` was deprecated in workflows 0.2.3.
#> Please use `extract_fit_parsnip()` instead.
#> internal: `pull_workflow_fit()` was deprecated in workflows 0.2.3.
#> Please use `extract_fit_parsnip()` instead.
#> # Resampling results
#> # 10-fold cross-validation 
#> # A tibble: 10 × 5
#>   splits             id     .metrics         .notes           .extracts       
#>   <list>             <chr>  <list>           <list>           <list>          
#> 1 <split [2107/235]> Fold01 <tibble [2 × 4]> <tibble [1 × 1]> <tibble [1 × 2]>
#> 2 <split [2107/235]> Fold02 <tibble [2 × 4]> <tibble [1 × 1]> <tibble [1 × 2]>
#> 3 <split [2108/234]> Fold03 <tibble [2 × 4]> <tibble [1 × 1]> <tibble [1 × 2]>
#> 4 <split [2108/234]> Fold04 <tibble [2 × 4]> <tibble [1 × 1]> <tibble [1 × 2]>
#> 5 <split [2108/234]> Fold05 <tibble [2 × 4]> <tibble [1 × 1]> <tibble [1 × 2]>
#> 6 <split [2108/234]> Fold06 <tibble [2 × 4]> <tibble [1 × 1]> <tibble [1 × 2]>
#> # … with 4 more rows
```