### PR TITLE
More concise group_by() call; fix tune option name

### DIFF
--- a/15-workflow-sets.Rmd
+++ b/15-workflow-sets.Rmd
@@ -56,8 +56,7 @@ To address this, we will use the mean compressive strength per concrete mixture 
 ```{r workflow-sets-means}
 concrete <- 
    concrete %>% 
-   group_by(cement, blast_furnace_slag, fly_ash, water, superplasticizer, 
-            coarse_aggregate, fine_aggregate, age) %>% 
+   group_by(across(-compressive_strength)) %>% 
    summarize(compressive_strength = mean(compressive_strength),
              .groups = "drop")
 nrow(concrete)
@@ -194,7 +193,7 @@ The `option` column is a placeholder for any arguments to use when we evaluate t
 ```{r workflow-sets-info-update}
 normalized <- 
    normalized %>% 
-   option_add(param = nnet_param, id = "normalized_neural_network")
+   option_add(param_info = nnet_param, id = "normalized_neural_network")
 normalized
 ```
 


### PR DESCRIPTION
* Instead of explicitly specifying all grouping variables in a `group_by()` call, it's shorter and less error-prone prone to specify variables *not* used for grouping.

* Calling `option_add(param = [...])` results in the following warning when the `parameters` object is added to a workflow which is passed to `workflow_map`:

      The `...` are not used in this function but one or more objects were passed: 'param'

  At least in `tune-0.1.6` the correct option name is `param_info`---this one worked for me.