### PR TITLE
Use `extract_parameter_dials()` instead of `pull_dials_object()`

### DIFF
--- a/12-tuning-parameters.Rmd
+++ b/12-tuning-parameters.Rmd
@@ -519,7 +519,7 @@ The `dials` package also has a convenience function for extracting a particular 
 
 ```{r tuning-extract}
 # identify the parameter using the id value:
-wflow_param %>% pull_dials_object("threshold")
+wflow_param %>% extract_parameter_dials("threshold")
 ```
 
 Inside the parameter set, the range of the parameters can also be updated in-place: 
@@ -571,10 +571,10 @@ updated_param <-
   parameters() %>% 
   finalize(ames_train)
 updated_param
-updated_param %>% pull_dials_object("mtry")
+updated_param %>% extract_parameter_dials("mtry")
 ```
 
-When the recipe is prepared, the `finalize()` function learns to set the upper range of `mtry` to  `r updated_param %>% pull_dials_object("mtry") %>% range_get() %>% pluck("upper")` predictors. 
+When the recipe is prepared, the `finalize()` function learns to set the upper range of `mtry` to  `r updated_param %>% extract_parameter_dials("mtry") %>% range_get() %>% pluck("upper")` predictors. 
 
 Additionally, the results of `parameters()` will include engine-specific parameters (if any) . They are discovered in the same way as the main arguments and included in the parameter set. The `r pkg(dials)` package contains parameter functions for all potentially tunable engine-specific parameters: 
 

--- a/13-grid-search.Rmd
+++ b/13-grid-search.Rmd
@@ -59,9 +59,9 @@ The argument `trace = 0` prevents extra logging of the training process. As show
 
 ```{r grid-mlp-param}
 mlp_param <- parameters(mlp_spec)
-mlp_param %>% pull_dials_object("hidden_units")
-mlp_param %>% pull_dials_object("penalty")
-mlp_param %>% pull_dials_object("epochs")
+mlp_param %>% extract_parameter_dials("hidden_units")
+mlp_param %>% extract_parameter_dials("penalty")
+mlp_param %>% extract_parameter_dials("epochs")
 ```
 
 This output indicates that the parameter objects are complete and prints their default ranges. These values will be used to demonstrate how to create different types of parameter grids. 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,8 +88,7 @@ Imports:
     xgboost,
     yardstick
 Remotes:
-    tidymodels/embed,
-    tidymodels/finetune,
+    tidymodels/dials,
     tidymodels/learntidymodels
 biocViews: mixOmics
 Encoding: UTF-8


### PR DESCRIPTION
I've deprecated `pull_dials_object()` in https://github.com/tidymodels/dials/pull/201 and replaced it here with the new `extract_parameter_dials()` function.

I'm not sure when you'd want to merge this PR, i.e. if you want to wait until the new dials version is on CRAN? Or should I add the dev version of dials to the DESCRIPTION so that the bookdown check is informative already now?