### PR TITLE
paragraph for pkg versions instead of table

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -86,16 +86,24 @@ cat(".\n")
 
 ## Using code examples {-}
 
-This book was written in [RStudio](http://www.rstudio.com/ide/) using [bookdown](http://bookdown.org/). The [website](https://tmwr.org) is hosted via [Netlify](http://netlify.com/), and automatically built after every push by [GitHub Actions](https://help.github.com/actions). The complete source is available on [GitHub](https://github.com/tidymodels/TMwR). We generated all plots in this book using [ggplot2](https://ggplot2.tidyverse.org/) and its black and white theme (`theme_bw()`). This version of the book was built with `r R.version.string`, [pandoc](https://pandoc.org/) version `r rmarkdown::pandoc_version()`, and the following packages:
-
-```{r pkg-list, echo = FALSE, results = "asis"}
+```{r pkg-list, echo = FALSE}
 deps <- desc::desc_get_deps()
 pkgs <- sort(deps$package[deps$type == "Imports"])
 pkgs <- sessioninfo::package_info(pkgs, dependencies = FALSE)
 df <- tibble::tibble(
   package = pkgs$package,
   version = pkgs$ondiskversion,
-  source = gsub("@", "\\\\@", pkgs$source)
-)
-knitr::kable(df, format = "markdown")
+  source = pkgs$source
+) %>% 
+  mutate(
+    source = stringr::str_split(source, " "),
+    source = purrr::map_chr(source, ~ .x[1]),
+    info = paste0(package, " (", version, ", ", source, ")")
+    )
+pkg_info <- knitr::combine_words(df$info)
 ```
+
+This book was written in [RStudio](http://www.rstudio.com/ide/) using [bookdown](http://bookdown.org/). The [website](https://tmwr.org) is hosted via [Netlify](http://netlify.com/), and automatically built after every push by [GitHub Actions](https://help.github.com/actions). The complete source is available on [GitHub](https://github.com/tidymodels/TMwR). We generated all plots in this book using [ggplot2](https://ggplot2.tidyverse.org/) and its black and white theme (`theme_bw()`). 
+
+This version of the book was built with `r R.version.string`, [pandoc](https://pandoc.org/) version `r rmarkdown::pandoc_version()`, and the following packages: `r pkg_info`.
+


### PR DESCRIPTION
The current book has a very long table. This PR generates a long paragraph instead (e.g. " applicable (0.0.1.2, CRAN), av (0.6.0, CRAN), baguette (0.1.1, CRAN), ..."). 