### PR TITLE
Update 09-judging-model-effectiveness.Rmd

### DIFF
--- a/09-judging-model-effectiveness.Rmd
+++ b/09-judging-model-effectiveness.Rmd
@@ -204,6 +204,9 @@ mcc(two_class_example, truth, predicted)
 
 # F1 metric:
 f_meas(two_class_example, truth, predicted)
+
+# Combining the three metrics together:
+metric_set(accuracy, mcc, f_meas)(two_class_example, truth = truth, estimate = predicted)
 ```
 
 For binary classification data sets, these functions have a standard argument called `event_level`. The _default_ is that the **first** level of the outcome factor is the event of interest. 


### PR DESCRIPTION
`metric_set()` also works for the classification metrics, and I think it should be brought up here. Just a quick thought.