### PR TITLE
use add_variables for #260

### DIFF
--- a/07-the-model-workflow.Rmd
+++ b/07-the-model-workflow.Rmd
@@ -326,7 +326,7 @@ ames_test  <-  testing(ames_split)
 lm_model <- linear_reg() %>% set_engine("lm")
 
 lm_wflow <- 
-  lm_wflow %>% 
+  workflow() %>% 
   add_model(lm_model) %>% 
   add_variables(outcome = Sale_Price, predictors = c(Longitude, Latitude))
 

--- a/07-the-model-workflow.Rmd
+++ b/07-the-model-workflow.Rmd
@@ -326,9 +326,9 @@ ames_test  <-  testing(ames_split)
 lm_model <- linear_reg() %>% set_engine("lm")
 
 lm_wflow <- 
-  workflow() %>% 
+  lm_wflow %>% 
   add_model(lm_model) %>% 
-  add_formula(Sale_Price ~ Longitude + Latitude)
+  add_variables(outcome = Sale_Price, predictors = c(Longitude, Latitude))
 
 lm_fit <- fit(lm_wflow, ames_train)
 ```


### PR DESCRIPTION
Closes #260 

To remove a disconnect between chapters 7 and 8.

The summary at the end of 7 was changed to use `add_variables()` so that, in chapter 8, the code 

```r
lm_wflow <- 
  lm_wflow %>% 
  remove_variables() %>% 
  add_recipe(simple_ames)
lm_wflow
```

makes more sense. 