### PR TITLE
Fix figure reference

### DIFF
--- a/04-ames.Rmd
+++ b/04-ames.Rmd
@@ -43,7 +43,7 @@ dim(ames)
 
 ## Exploring Important Features
 
-Let's start with the outcome we want to predict: the last sale price of the house (in USD), as shown in Figure \@ref(fig:ames-sale-price).
+Let's start with the outcome we want to predict: the last sale price of the house (in USD), as shown in Figure \@ref(fig:ames-sale-price-hist).
 
 ```{r ames-sale-price-code, eval = FALSE}
 library(tidymodels)


### PR DESCRIPTION
This is a quick PR to fix a figure reference for "The Ames Housing Data" chapter. Currently, the text references Figure 5.1. I think that this reference should point to Figure 4.1.

A image of the current text is below:
<img width="813" alt="image" src="https://user-images.githubusercontent.com/19840652/162363004-38fe7e61-c778-48f9-944c-266bedbfd4bb.png">


