### PR TITLE
Adjust random number stream

### DIFF
--- a/05-data-spending.Rmd
+++ b/05-data-spending.Rmd
@@ -82,7 +82,7 @@ quart_plot
 As previously discussed, the sale price distribution is right-skewed, with proportionally more inexpensive houses than expensive houses on either side of the center of the distribution. The worry here with simple splitting is that the more expensive houses would not be well represented in the training set; this would increase the risk that our model would be ineffective at predicting the price for such properties.  The dotted vertical lines in Figure \@ref(fig:ames-sale-price) indicate the four quartiles for these data. A stratified random sample would conduct the 80/20 split within each of these data subsets and then pool the results together. In `r pkg(rsample)`, this is achieved using the `strata` argument: 
 
 ```{r ames-strata-split}
-set.seed(502)
+set.seed(123)
 ames_split <- initial_split(ames, prop = 0.80, strata = Sale_Price)
 ames_train <- training(ames_split)
 ames_test  <-  testing(ames_split)
@@ -157,7 +157,7 @@ library(tidymodels)
 data(ames)
 ames <- ames %>% mutate(Sale_Price = log10(Sale_Price))
 
-set.seed(502)
+set.seed(123)
 ames_split <- initial_split(ames, prop = 0.80, strata = Sale_Price)
 ames_train <- training(ames_split)
 ames_test  <-  testing(ames_split)


### PR DESCRIPTION
In chunck `models-summary` (chapter 6.6) the random number stream is set to 123 (`set.seed(123)`). However, since `eval=FALSE` the defined random number stream 502 from chunk `ames-strata-split` (chapter 5.1) is used in the following instead of the desired 123. This leads to unexpected model outputs when running chunk `workflows-form-fit` (chapter 7.2) where currently the following appears (based on `set.seed(502)`)

```
#> Coefficients:
#> (Intercept)    Longitude     Latitude  
#>     -302.97        -2.07         2.71
```
However, using the values defined in chapter 6.6 (incl. `set.seed(123)`)
> Using the objects created in Section [6.6](https://www.tmwr.org/models.html#models-summary):

actually gives:
```
#> Coefficients:
#> (Intercept)    Longitude     Latitude  
#>     -300.251       -2.013        2.782  
```

I suggest to either adjust the random number stream or set `eval=TRUE` in chunk `models-summary`.