### PR TITLE
Fix doc typos

### DIFF
--- a/09-judging-model-effectiveness.Rmd
+++ b/09-judging-model-effectiveness.Rmd
@@ -57,7 +57,7 @@ This chapter will demonstrate the `r pkg(yardstick)` package, a core tidymodels 
 ad_mod <- logistic_reg() %>% set_engine("glm") 
 full_model_fit <-
   ad_mod %>% 
-  fit(Class ~ (Genotype + male + age)^3, , data = ad_data)
+  fit(Class ~ (Genotype + male + age)^3, data = ad_data)
 
 full_model_fit %>% extract_fit_engine() 
 

--- a/11-comparing-models.Rmd
+++ b/11-comparing-models.Rmd
@@ -54,9 +54,7 @@ preproc <-
        splines = spline_rec
   )
 
-lm_model <- linear_reg() |> set_engine("lm")
-
-lm_models <- workflow_set(preproc, list(lm = lm_model), cross = FALSE)
+lm_models <- workflow_set(preproc, list(lm = linear_reg()), cross = FALSE)
 lm_models
 ```
 

--- a/11-comparing-models.Rmd
+++ b/11-comparing-models.Rmd
@@ -54,6 +54,8 @@ preproc <-
        splines = spline_rec
   )
 
+lm_model <- linear_reg() |> set_engine("lm")
+
 lm_models <- workflow_set(preproc, list(lm = lm_model), cross = FALSE)
 lm_models
 ```


### PR DESCRIPTION
1. Omitted an extra comma.
2.  In Chapter 11 in the code chunk "compare-workflow-set", the object 'lm-model' was not explicitly defined. When I copied and pasted it into the console, I received an error message "object not found."  Only after prepping the pull request did I see it was loaded in the 'introduction-setup' chunk.  Maybe, it would be better to have it explicitly shown?

Thanks for all the hard work!
--rob