### PR TITLE
Suggestion: import Orthodont data

### DIFF
--- a/07-the-model-workflow.Rmd
+++ b/07-the-model-workflow.Rmd
@@ -183,16 +183,14 @@ A number of multilevel models have standardized on a formula specification devis
 
 ```r
 library(lme4)
+data(Orthodont, package = "nlme") # load the Orthodont data from the nlme package
+
 lmer(distance ~ Sex + (age | Subject), data = Orthodont)
 ```
 
 The effect of this is that each subject will have an estimated intercept and slope parameter for `age`. 
 
 The problem is that standard R methods can't properly process this formula: 
-
-```{r echo=FALSE}
-data(Orthodont, package = "nlme")
-```
 
 ```{r workflows-rand-mm, error=TRUE}
 model.matrix(distance ~ Sex + (age | Subject), data = Orthodont)


### PR DESCRIPTION
As written, the text seems to imply that the Orthodont data is from the lme4 package. Suggest moving and visibly reading in the data from the nlme package before the first linear model in section 7.4.1 to avoid confusion.