### PR TITLE
Fix copy paste error on alt text

### DIFF
--- a/12-tuning-parameters.Rmd
+++ b/12-tuning-parameters.Rmd
@@ -474,7 +474,8 @@ How can we signal to tidymodels functions which arguments should be optimized?  
 
 ```{r tuning-mlp-units}
 neural_net_spec <- 
-  mlp(hidden_units = tune()) %>% 
+  mlp(hidden_units = tune()) %>%
+  set_mode("regression") %>%
   set_engine("keras")
 ```
 
@@ -566,7 +567,8 @@ In some cases, it is easy to have reasonable defaults for the range of possible 
 ```{r tuning-rf}
 rf_spec <- 
   rand_forest(mtry = tune()) %>% 
-  set_engine("ranger", regularization.factor = tune("regularization"))
+  set_engine("ranger", regularization.factor = tune("regularization")) %>%
+  set_mode("regression")
 
 rf_param <- extract_parameter_set_dials(rf_spec)
 rf_param

--- a/16-dimensionality-reduction.Rmd
+++ b/16-dimensionality-reduction.Rmd
@@ -418,7 +418,7 @@ bean_rec_trained %>%
 #| echo = FALSE,
 #| fig.height = 7,
 #| fig.cap = "UMAP component scores for the bean validation set, colored by class",
-#| fig.alt = "UMAP component scores for the bean validation set, colored by class. Many bean classes, which appear as color blobs, are drawn far away from other blobs."
+#| fig.alt = "UMAP component scores for the bean validation set, colored by class. There is a very high degree of separation between clusters, but several of the clusters contain more than one class."
 ```
 
 While the between-cluster space is pronounced, the clusters can contain a heterogeneous mixture of classes.
@@ -437,7 +437,7 @@ bean_rec_trained %>%
 #| echo = FALSE,
 #| fig.height = 7,
 #| fig.cap = "Supervised UMAP component scores for the bean validation set, colored by class",
-#| fig.alt = "Supervised UMAP component scores for the bean validation set, colored by class. There is significant overlap in the first two ICA components."
+#| fig.alt = "Supervised UMAP component scores for the bean validation set, colored by class. There is again a very high degree of separation between clusters, and there are now fewer instances of one cluster containing multiple classes."
 ```
 
 The supervised method shown in Figure \@ref(fig:bean-umap-supervised) looks promising for modeling the data.

--- a/16-dimensionality-reduction.Rmd
+++ b/16-dimensionality-reduction.Rmd
@@ -418,7 +418,7 @@ bean_rec_trained %>%
 #| echo = FALSE,
 #| fig.height = 7,
 #| fig.cap = "UMAP component scores for the bean validation set, colored by class",
-#| fig.alt = "UMAP component scores for the bean validation set, colored by class. There is significant overlap in the first two ICA components."
+#| fig.alt = "UMAP component scores for the bean validation set, colored by class. Many bean classes, which appear as color blobs, are drawn far away from other blobs."
 ```
 
 While the between-cluster space is pronounced, the clusters can contain a heterogeneous mixture of classes.


### PR DESCRIPTION
The old text was a copy paste error from the last figure.  This describes the pattern in this figure.