### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.Rmd linguist-detectable


### PR DESCRIPTION
to provide `*.Rmd` file-type detection on github repo