### PR TITLE
remove duplicated periods after footnotes

### DIFF
--- a/10-resampling.Rmd
+++ b/10-resampling.Rmd
@@ -107,7 +107,7 @@ The test set RMSE estimate, `r all_res %>% filter(object == "rf_fit") %>% pull("
 Many predictive models are capable of learning complex trends from the data. In statistics, these are commonly referred to as _low bias models_. 
 
 :::rmdnote
-In this context, _bias_ is the difference between the true pattern or relationships in data and the types of patterns that the model can emulate. Many black-box machine learning models have low bias, meaning they can reproduce complex relationships. Other models (such as linear/logistic regression, discriminant analysis, and others) are not as adaptable and are considered _high bias_ models.^[See Section 1.2.5 of @fes for a discussion: <https://bookdown.org/max/FES/important-concepts.html#model-bias-and-variance>].
+In this context, _bias_ is the difference between the true pattern or relationships in data and the types of patterns that the model can emulate. Many black-box machine learning models have low bias, meaning they can reproduce complex relationships. Other models (such as linear/logistic regression, discriminant analysis, and others) are not as adaptable and are considered _high bias_ models.^[See Section 1.2.5 of @fes for a discussion: <https://bookdown.org/max/FES/important-concepts.html#model-bias-and-variance>]
 :::
 
 For a low bias model, the high degree of predictive capacity can sometimes result in the model nearly memorizing the training set data. As an obvious example, consider a 1-nearest neighbor model. It will always provide perfect predictions for the training set no matter how well it truly works for other data sets. Random forest models are similar; repredicting the training set will always result in an artificially optimistic estimate of performance.  
@@ -191,7 +191,7 @@ When _V_ = 3, the analysis sets are 2/3 of the training set and each assessment 
 Using _V_ = 3 is a good choice to illustrate cross-validation, but it is a poor choice in practice because it is too low to generate reliable estimates. In practice, values of _V_ are most often 5 or 10; we generally prefer 10-fold cross-validation as a default because it is large enough for good results in most situations. 
 
 :::rmdnote
-What are the effects of changing _V_? Larger values result in resampling estimates with small bias but substantial variance. Smaller values of _V_ have large bias but low variance. We prefer 10-fold since noise is reduced by replication, but bias is not.^[See Section 3.4 of @fes for a longer description of the results of changing _V_: <https://bookdown.org/max/FES/resampling.html>]. 
+What are the effects of changing _V_? Larger values result in resampling estimates with small bias but substantial variance. Smaller values of _V_ have large bias but low variance. We prefer 10-fold since noise is reduced by replication, but bias is not.^[See Section 3.4 of @fes for a longer description of the results of changing _V_: <https://bookdown.org/max/FES/resampling.html>] 
 :::
 
 The primary input is the training set data frame as well as the number of folds (defaulting to 10): 


### PR DESCRIPTION
I came across a couple spots in Ch 10 this morning where a duplicate period is placed after a footnote. Fixes:

> high bias models.[17](https://www.tmwr.org/resampling.html#fn17).

and 

> but bias is not.[19](https://www.tmwr.org/resampling.html#fn19).

🙂