### PR TITLE
Chapter 11 code: Adding code to create ames_test in first recipe setup

### DIFF
--- a/11-comparing-models.Rmd
+++ b/11-comparing-models.Rmd
@@ -38,6 +38,8 @@ ames_split <- initial_split(ames, prop = 0.80, strata = Sale_Price)
 ames_train <- training(ames_split)
 ames_test  <-  testing(ames_split)
 ames_folds <- vfold_cv(ames_train, v = 10)
+keep_pred <- control_resamples(save_pred = TRUE, save_workflow = TRUE)
+
 
 basic_rec <- 
   recipe(Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type + 

--- a/11-comparing-models.Rmd
+++ b/11-comparing-models.Rmd
@@ -37,6 +37,7 @@ set.seed(502)
 ames_split <- initial_split(ames, prop = 0.80, strata = Sale_Price)
 ames_train <- training(ames_split)
 ames_test  <-  testing(ames_split)
+ames_folds <- vfold_cv(ames_train, v = 10)
 
 basic_rec <- 
   recipe(Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type + 

--- a/11-comparing-models.Rmd
+++ b/11-comparing-models.Rmd
@@ -33,6 +33,11 @@ In Section \@ref(workflow-sets-intro) we described the idea of a workflow set wh
 library(tidymodels)
 tidymodels_prefer()
 
+set.seed(502)
+ames_split <- initial_split(ames, prop = 0.80, strata = Sale_Price)
+ames_train <- training(ames_split)
+ames_test  <-  testing(ames_split)
+
 basic_rec <- 
   recipe(Sale_Price ~ Neighborhood + Gr_Liv_Area + Year_Built + Bldg_Type + 
            Latitude + Longitude, data = ames_train) %>%


### PR DESCRIPTION
In the opening to chapter 11, there is a creation of a basic recipe for a workflow set.  It uses the ames_train dataset from prior chapters.  It looks as if the opening script should be stand alone.  If so, the ames_train dataset should be created in that snippet.  This pull request adds the creation of that dataset.