### PR TITLE
Use `linewidth` arg for ggplot2

### DIFF
--- a/11-comparing-models.Rmd
+++ b/11-comparing-models.Rmd
@@ -140,7 +140,7 @@ These correlations are high, and indicate that, across models, there are large w
 rsq_indiv_estimates %>% 
   mutate(wflow_id = reorder(wflow_id, .estimate)) %>% 
   ggplot(aes(x = wflow_id, y = .estimate, group = id, color = id)) + 
-  geom_line(alpha = .5, lwd = 1.25) + 
+  geom_line(alpha = .5, linewidth = 1.25) + 
   theme(legend.position = "none")
 ```
 

--- a/18-explaining-models-and-predictions.Rmd
+++ b/18-explaining-models-and-predictions.Rmd
@@ -274,12 +274,12 @@ ggplot_imp <- function(...) {
     p <- p + 
       facet_wrap(vars(label)) +
       geom_vline(data = perm_vals, aes(xintercept = dropout_loss, color = label),
-                 size = 1.4, lty = 2, alpha = 0.7) +
+                 linewidth = 1.4, lty = 2, alpha = 0.7) +
       geom_boxplot(aes(color = label, fill = label), alpha = 0.2)
   } else {
     p <- p + 
       geom_vline(data = perm_vals, aes(xintercept = dropout_loss),
-                 size = 1.4, lty = 2, alpha = 0.7) +
+                 linewidth = 1.4, lty = 2, alpha = 0.7) +
       geom_boxplot(fill = "#91CBD765", alpha = 0.4)
     
   }
@@ -330,14 +330,14 @@ ggplot_pdp <- function(obj, x) {
     ggplot(aes(`_x_`, `_yhat_`)) +
     geom_line(data = as_tibble(obj$cp_profiles),
               aes(x = {{ x }}, group = `_ids_`),
-              size = 0.5, alpha = 0.05, color = "gray50")
+              linewidth = 0.5, alpha = 0.05, color = "gray50")
   
   num_colors <- n_distinct(obj$agr_profiles$`_label_`)
   
   if (num_colors > 1) {
-    p <- p + geom_line(aes(color = `_label_`), size = 1.2, alpha = 0.8)
+    p <- p + geom_line(aes(color = `_label_`), linewidth = 1.2, alpha = 0.8)
   } else {
-    p <- p + geom_line(color = "midnightblue", size = 1.2, alpha = 0.8)
+    p <- p + geom_line(color = "midnightblue", linewidth = 1.2, alpha = 0.8)
   }
   
   p
@@ -391,8 +391,8 @@ as_tibble(pdp_liv$agr_profiles) %>%
   ggplot(aes(`_x_`, `_yhat_`, color = Bldg_Type)) +
   geom_line(data = as_tibble(pdp_liv$cp_profiles),
             aes(x = Gr_Liv_Area, group = `_ids_`),
-            size = 0.5, alpha = 0.1, color = "gray50") +
-  geom_line(size = 1.2, alpha = 0.8, show.legend = FALSE) +
+            linewidth = 0.5, alpha = 0.1, color = "gray50") +
+  geom_line(linewidth = 1.2, alpha = 0.8, show.legend = FALSE) +
   scale_x_log10() +
   facet_wrap(~Bldg_Type) +
   scale_color_brewer(palette = "Dark2") +

--- a/19-when-should-you-trust-predictions.Rmd
+++ b/19-when-should-you-trust-predictions.Rmd
@@ -165,7 +165,7 @@ eq_zone_results <- function(buffer) {
 map_dfr(seq(0, .1, length.out = 40), eq_zone_results) %>% 
   pivot_longer(c(-buffer), names_to = "statistic", values_to = "value") %>% 
   ggplot(aes(x = buffer, y = value, lty = statistic)) + 
-  geom_step(size = 1.2, alpha = 0.8) + 
+  geom_step(linewidth = 1.2, alpha = 0.8) + 
   labs(y = NULL, lty = NULL)
 ```
 


### PR DESCRIPTION
to avoid deprecation warnings from ggplot2 v3.4.0, see also https://www.tidyverse.org/blog/2022/11/ggplot2-3-4-0/#hello-linewidth