### PR TITLE
Tweak language about poissonreg in chapter 21

### DIFF
--- a/21-inferential-analysis.Rmd
+++ b/21-inferential-analysis.Rmd
@@ -198,7 +198,7 @@ $$
 
 where $\lambda$ is the expected value of the counts.
 
-Let's fit a simple model that contains all of the predictor columns. The `r pkg(poissonreg)` package, a `r pkg(parsnip)` extension package in tidymodels, will create this model specification:
+Let's fit a simple model that contains all of the predictor columns. The `r pkg(poissonreg)` package, a `r pkg(parsnip)` extension package in tidymodels, will fit this model specification:
 
 ```{r inferential-glm}
 library(poissonreg)


### PR DESCRIPTION
The model specification now lives in parsnip, but poissonreg is still required to _fit_ the model since it contains the engines for `poisson_reg()`.